### PR TITLE
add mesh subdomain with paul as NS

### DIFF
--- a/ffhl.zone
+++ b/ffhl.zone
@@ -1,7 +1,7 @@
 $ORIGIN ffhl.
 $TTL 10m  ; FIXME: Sobald alles läuft auf ein paar Tage erhöhen!
 ffhl.  IN  SOA  burgtor.ffhl. freifunk\.luebeck.asta.uni-luebeck.de. (
-              1335813437 ; serial number of this zone file
+              1336872018 ; serial number of this zone file
               1h         ; slave refresh
               3m         ; slave retry time in case of a problem
               1h         ; slave expiration time
@@ -46,3 +46,7 @@ derderwish    A     10.130.16.3
 dysis         A     10.130.16.8
 
 ; clients
+
+; subdomains
+mesh.ffhl.    IN NS paul.ffhl.
+


### PR DESCRIPTION
the NS on paul runs an mdns-to-dns-bridge and resolves local domain
names announced by the clients via avahi/zeroconf. The ffhl-NS should
delegate the mesh.ffhl. zone to paul and may be more servers running
this bridge, later.
