### PR TITLE
yacy.ffhl, search.ffhl und suche.ffhl angelegt

### DIFF
--- a/ffhl.zone
+++ b/ffhl.zone
@@ -1,7 +1,7 @@
 $ORIGIN ffhl.
 $TTL 10m  ; FIXME: Sobald alles läuft auf ein paar Tage erhöhen!
 ffhl.  IN  SOA  burgtor.ffhl. freifunk\.luebeck.asta.uni-luebeck.de. (
-              1393198917 ; serial number of this zone file
+              1393198918 ; serial number of this zone file
               1h         ; slave refresh
               3m         ; slave retry time in case of a problem
               1h         ; slave expiration time
@@ -92,6 +92,11 @@ zenforyen     A     10.130.118.2
 chip          A     10.130.16.2
 
 derderwish    A     10.130.16.3
+
+yacy          A     10.130.123.14
+              AAAA  fdef:ffc0:3dd7:7b::e
+suche         CNAME yacy
+search        CNAME yacy
 
 dysis         A     10.130.16.8
 


### PR DESCRIPTION
Hab mir mal diese Adressen für das Suchmaschinchen angelegt:
yacy.ffhl, 
search.ffhl
suche.ffhl

Die Reverse-Auflösung ist nicht drin, denn diese verwaltet ja krtek für das Meutenetz.

Bitte einmal drüber schauen und bei keiner Beanstandung einpflegen. Danke!
